### PR TITLE
Fix typo in default development config

### DIFF
--- a/config/en/imports/develop.nss
+++ b/config/en/imports/develop.nss
@@ -19,7 +19,7 @@
 		menu(mode="multiple" sep="both" title='publish' image=\ue11f)
 		{
 			var { publish='dotnet publish -r win-x64 -c release --output "@sel.parent\publish" /p:CopyOutputSymbolsToPublishDirectory=false' }
-			item(title='publish sinale file' sep="after" cmd-line='/K @publish -p:PublishSingleFile=true --self-contained false')
+			item(title='publish single file' sep="after" cmd-line='/K @publish -p:PublishSingleFile=true --self-contained false')
 			item(title='framework-dependent deployment' cmd-line='/K @publish')
 			item(title='framework-dependent executable' cmd-line='/K @publish --self-contained false')
 			item(title='self-contained deployment' cmd-line='/K @publish --self-contained true')


### PR DESCRIPTION
- Updates context menu text from 'publish sinale file' to 'publish single file'