### PR TITLE
Minor tweaks to File Manage menu

### DIFF
--- a/config/en/imports/file-manage.nss
+++ b/config/en/imports/file-manage.nss
@@ -1,4 +1,4 @@
-﻿menu(where=sel.count>0 type='file|dir|drive|namespace|back' mode="multiple" title='File Manage' image=\uE253)
+﻿menu(where=sel.count>0 type='file|dir|drive|namespace|back' mode="multiple" title='File manage' image=\uE253)
 {
 	menu(separator="after" title=title.copy_path image=icon.copy_path)
 	{
@@ -23,7 +23,7 @@
 		item(title="None" image=icon.select_none cmd=command.select_none)
 	}
 
-	item(type='file|dir|back.dir|drive' title='Take Ownership' image=[\uE194,#f00] admin
+	item(type='file|dir|back.dir|drive' title='Take ownership' image=[\uE194,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
 	menu(title="Show/Hide" image=icon.show_hidden_files)

--- a/config/en/imports/file-manage.nss
+++ b/config/en/imports/file-manage.nss
@@ -32,7 +32,7 @@
 		item(title="File name extensions" image=icon.show_file_extensions cmd='@command.toggleext')
 	}
 
-	menu(type='file|dir|back.dir' mode="single" title='Attributes')
+	menu(type='file|dir|back.dir' mode="single" title='Attributes' image=icon.properties)
 	{
 		$atrr = io.attributes(sel.path)
 		item(title='Hidden' checked=io.attribute.hidden(atrr)

--- a/config/en/imports/file-manage.nss
+++ b/config/en/imports/file-manage.nss
@@ -13,16 +13,16 @@
 		item(mode="single" type='file' where=sel.file.ext.len>0 title=sel.file.ext cmd=command.copy(sel.file.ext))
 	}
 
-	item(mode="single" type="file" title="Change extension" image=\uE0B5 cmd=if(input("Change extension", "Type extension"), 
+	item(mode="single" type="file" title="Change extension" image=\uE0B5 cmd=if(input("Change extension", "Type extension"),
 		io.rename(sel.path, path.join(sel.dir, sel.file.title + "." + input.result))))
-	
+
 	menu(separator="after" image=\uE290 title=title.select)
 	{
 		item(title="All" image=icon.select_all cmd=command.select_all)
 		item(title="Invert" image=icon.invert_selection cmd=command.invert_selection)
 		item(title="None" image=icon.select_none cmd=command.select_none)
 	}
-	
+
 	item(type='file|dir|back.dir|drive' title='Take Ownership' image=[\uE194,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
@@ -37,19 +37,19 @@
 		$atrr = io.attributes(sel.path)
 		item(title='Hidden' checked=io.attribute.hidden(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.hidden(atrr),"-","+")H "@sel.path"' window=hidden)
-		
+
 		item(title='System' checked=io.attribute.system(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.system(atrr),"-","+")S "@sel.path"' window=hidden)
-			
+
 		item(title='Read-Only' checked=io.attribute.readonly(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.readonly(atrr),"-","+")R "@sel.path"' window=hidden)
-			
+
 		item(title='Archive' checked=io.attribute.archive(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.archive(atrr),"-","+")A "@sel.path"' window=hidden)
 		separator
-		item(title="CREATED" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1))
-		item(title="MODIFIED" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1))
-		item(title="ACCESSED" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1))
+		item(title="Created" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1) vis=label)
+		item(title="Modified" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1) vis=label)
+		item(title="Accessed" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1) vis=label)
 	}
 
 	menu(mode="single" type='file' find='.dll|.ocx' separator="before" title='Register Server' image=\uea86)
@@ -65,16 +65,16 @@
 			item(title='DateTime' cmd=io.dir.create(sys.datetime("ymdHMSs")))
 			item(title='Guid' cmd=io.dir.create(str.guid))
 		}
-		
+
 		menu(title='New File' image=icon.new_file)
 		{
 			$dt = sys.datetime("ymdHMSs")
 			item(title='TXT' cmd=io.file.create('@(dt).txt', 'Hello World!'))
 			item(title='XML' cmd=io.file.create('@(dt).xml', '<root>Hello World!</root>'))
 			item(title='JSON' cmd=io.file.create('@(dt).json', '[]'))
-			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))					
+			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))
 		}
 	}
-	
+
 	item(where=!wnd.is_desktop title=title.folder_options image=icon.folder_options cmd=command.folder_options)
 }

--- a/config/ko/imports/file-manage.nss
+++ b/config/ko/imports/file-manage.nss
@@ -13,16 +13,16 @@
 		item(mode="single" type='file' where=sel.file.ext.len>0 title=sel.file.ext cmd=command.copy(sel.file.ext))
 	}
 
-	item(mode="single" type="file" title="확장자 변경" image=\uE0B5 cmd=if(input("Change extension", "Type extension"), 
+	item(mode="single" type="file" title="확장자 변경" image=\uE0B5 cmd=if(input("Change extension", "Type extension"),
 		io.rename(sel.path, path.join(sel.dir, sel.file.title + "." + input.result))))
-	
+
 	menu(separator="after" image=\uE290 title=title.select)
 	{
-		item(title="모두" image=icon.select_all cmd=command.select_all)
-		item(title="반전" image=icon.invert_selection cmd=command.invert_selection)
-		item(title="없음" image=icon.select_none cmd=command.select_none)
+		item(title="모두" image=icon.select_all cmd=command.select_all vis=label)
+		item(title="반전" image=icon.invert_selection cmd=command.invert_selection vis=label)
+		item(title="없음" image=icon.select_none cmd=command.select_none vis=label)
 	}
-	
+
 	item(type='file|dir|back.dir|drive' title='소유권 획득' image=[\uE194,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
@@ -37,13 +37,13 @@
 		$atrr = io.attributes(sel.path)
 		item(title='숨김' checked=io.attribute.hidden(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.hidden(atrr),"-","+")H "@sel.path"' window=hidden)
-		
+
 		item(title='시스템' checked=io.attribute.system(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.system(atrr),"-","+")S "@sel.path"' window=hidden)
-			
+
 		item(title='읽기 전용' checked=io.attribute.readonly(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.readonly(atrr),"-","+")R "@sel.path"' window=hidden)
-			
+
 		item(title='보관 가능' checked=io.attribute.archive(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.archive(atrr),"-","+")A "@sel.path"' window=hidden)
 		separator
@@ -65,16 +65,16 @@
 			item(title='날짜 시간' cmd=io.dir.create(sys.datetime("ymdHMSs")))
 			item(title='가이드' cmd=io.dir.create(str.guid))
 		}
-		
+
 		menu(title='새 파일' image=icon.new_file)
 		{
 			$dt = sys.datetime("ymdHMSs")
 			item(title='TXT' cmd=io.file.create('@(dt).txt', 'Hello World!'))
 			item(title='XML' cmd=io.file.create('@(dt).xml', '<root>Hello World!</root>'))
 			item(title='JSON' cmd=io.file.create('@(dt).json', '[]'))
-			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))					
+			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))
 		}
 	}
-	
+
 	item(where=!wnd.is_desktop title=title.folder_options image=icon.folder_options cmd=command.folder_options)
 }

--- a/config/ko/imports/file-manage.nss
+++ b/config/ko/imports/file-manage.nss
@@ -32,7 +32,7 @@
 		item(title="파일 이름 확장자" image=icon.show_file_extensions cmd='@command.toggleext')
 	}
 
-	menu(type='file|dir|back.dir' mode="single" title='속성')
+	menu(type='file|dir|back.dir' mode="single" title='속성' image=icon.properties)
 	{
 		$atrr = io.attributes(sel.path)
 		item(title='숨김' checked=io.attribute.hidden(atrr)

--- a/config/pt-br/imports/file-manage.nss
+++ b/config/pt-br/imports/file-manage.nss
@@ -12,14 +12,14 @@
 		item(mode="single" type='file' where=sel.file.len != sel.file.title.len title=@sel.file.title cmd=command.copy(sel.file.title))
 		item(mode="single" type='file' where=sel.file.ext.len>0 title=sel.file.ext cmd=command.copy(sel.file.ext))
 	}
-	
+
 	menu(separator="after" image=\uE290 title=title.select)
 	{
 		item(title="Todos" image=icon.select_all cmd=command.select_all)
 		item(title="Inverter" image=icon.invert_selection cmd=command.invert_selection)
 		item(title="Nenhum" image=icon.select_none cmd=command.select_none)
 	}
-	
+
 	item(type='file|dir|back.dir|drive' title='Tornar-se Proprietário' image=[\uE1DE,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
@@ -34,19 +34,19 @@
 		var { atrr = io.attributes(sel.path) }
 		item(title='Oculto' checked=io.attribute.hidden(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.hidden(atrr),"-","+")H "@sel.path"' window=hidden)
-		
+
 		item(title='Sistema' checked=io.attribute.system(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.system(atrr),"-","+")S "@sel.path"' window=hidden)
-			
+
 		item(title='Somente leitura' checked=io.attribute.readonly(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.readonly(atrr),"-","+")R "@sel.path"' window=hidden)
-			
+
 		item(title='Arquivar' checked=io.attribute.archive(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.archive(atrr),"-","+")A "@sel.path"' window=hidden)
 		separator
-		item(title="CRIADO" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1))
-		item(title="MODIFICADO" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1))
-		item(title="ACESSADO" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1))
+		item(title="Criado" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1) vis=label)
+		item(title="Modificado" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1) vis=label)
+		item(title="Acessado" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1) vis=label)
 	}
 
 	menu(mode="single" type='file' find='.dll|.ocx' separator="before" title='Servidor de Registro' image=\uea86)
@@ -62,16 +62,16 @@
 			item(title='DataHora' cmd=io.dir.create(sys.datetime("ymdHMSs")))
 			item(title='Guid' cmd=io.dir.create(str.guid))
 		}
-		
+
 		menu(title='Novo Arquivo' image=icon.new_file)
 		{
 			var { dt = sys.datetime("ymdHMSs")}
 			item(title='TXT' cmd=io.file.create('@(dt).txt', 'Hello World!'))
 			item(title='XML' cmd=io.file.create('@(dt).xml', '<root>Hello World!</root>'))
 			item(title='JSON' cmd=io.file.create('@(dt).json', '[]'))
-			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))					
+			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))
 		}
 	}
-	
+
 	item(where=!wnd.is_desktop title=title.folder_options image=icon.folder_options cmd=command.folder_options)
 }

--- a/config/pt-br/imports/file-manage.nss
+++ b/config/pt-br/imports/file-manage.nss
@@ -29,7 +29,7 @@
 		item(title="Extensões de arquivos" image=icon.show_file_extensions cmd='@command.toggleext')
 	}
 
-	menu(type='file|dir|back.dir' mode="single" title='Atributos')
+	menu(type='file|dir|back.dir' mode="single" title='Atributos' image=icon.properties)
 	{
 		var { atrr = io.attributes(sel.path) }
 		item(title='Oculto' checked=io.attribute.hidden(atrr)

--- a/config/pt-br/imports/file-manage.nss
+++ b/config/pt-br/imports/file-manage.nss
@@ -1,4 +1,4 @@
-﻿menu(where=sel.count>0 type='file|dir|drive|namespace|back' mode="multiple" title='Gerenciamento de Arquivos' image=\uE253)
+﻿menu(where=sel.count>0 type='file|dir|drive|namespace|back' mode="multiple" title='Gerenciamento de arquivos' image=\uE253)
 {
 	menu(separator="after" title=title.copy_path image=icon.copy_path)
 	{
@@ -20,7 +20,7 @@
 		item(title="Nenhum" image=icon.select_none cmd=command.select_none)
 	}
 
-	item(type='file|dir|back.dir|drive' title='Tornar-se Proprietário' image=[\uE1DE,#f00] admin
+	item(type='file|dir|back.dir|drive' title='Tornar-se proprietário' image=[\uE1DE,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
 	menu(title="Mostrar/Ocultar" image=icon.show_hidden_files)

--- a/config/zh/imports/file-manage.nss
+++ b/config/zh/imports/file-manage.nss
@@ -29,7 +29,7 @@
 		item(title="文件扩展名" image=icon.show_file_extensions cmd='@command.toggleext')
 	}
 
-	menu(type='file|dir|back.dir' mode="single" title='属性')
+	menu(type='file|dir|back.dir' mode="single" title='属性' image=icon.properties)
 	{
 		var { atrr = io.attributes(sel.path) }
 		item(title='隐藏的' checked=io.attribute.hidden(atrr)

--- a/config/zh/imports/file-manage.nss
+++ b/config/zh/imports/file-manage.nss
@@ -12,14 +12,14 @@
 		item(mode="single" type='file' where=sel.file.len != sel.file.title.len title=@sel.file.title cmd=command.copy(sel.file.title))
 		item(mode="single" type='file' where=sel.file.ext.len>0 title=sel.file.ext cmd=command.copy(sel.file.ext))
 	}
-	
+
 	menu(separator="after" image=\uE290 title=title.select)
 	{
 		item(title="全部" image=icon.select_all cmd=command.select_all)
 		item(title="倒序" image=icon.invert_selection cmd=command.invert_selection)
 		item(title="取消" image=icon.select_none cmd=command.select_none)
 	}
-	
+
 	item(type='file|dir|back.dir|drive' title='取得文件所有权' image=[\uE194,#f00] admin
 		cmd args='/K takeown /f "@sel.path" @if(sel.type==1,null,"/r /d y") && icacls "@sel.path" /grant *S-1-5-32-544:F @if(sel.type==1,"/c /l","/t /c /l /q")')
 	separator
@@ -34,19 +34,19 @@
 		var { atrr = io.attributes(sel.path) }
 		item(title='隐藏的' checked=io.attribute.hidden(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.hidden(atrr),"-","+")H "@sel.path"' window=hidden)
-		
+
 		item(title='系统' checked=io.attribute.system(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.system(atrr),"-","+")S "@sel.path"' window=hidden)
-			
+
 		item(title='只读' checked=io.attribute.readonly(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.readonly(atrr),"-","+")R "@sel.path"' window=hidden)
-			
+
 		item(title='存档' checked=io.attribute.archive(atrr)
 			cmd args='/c ATTRIB @if(io.attribute.archive(atrr),"-","+")A "@sel.path"' window=hidden)
 		separator
-		item(title="创建" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1))
-		item(title="被修改的" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1))
-		item(title="访问" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1))
+		item(title="创建" keys=io.dt.created(sel.path, 'y/m/d') cmd=io.dt.created(sel.path,2000,1,1) vis=label)
+		item(title="被修改的" keys=io.dt.modified(sel.path, 'y/m/d') cmd=io.dt.modified(sel.path,2000,1,1) vis=label)
+		item(title="访问" keys=io.dt.accessed(sel.path, 'y/m/d') cmd=io.dt.accessed(sel.path,2000,1,1) vis=label)
 	}
 
 	menu(mode="single" type='file' find='.dll|.ocx' separator="before" title='Register Server' image=\uea86)
@@ -62,16 +62,16 @@
 			item(title='以时间命名' cmd=io.dir.create(sys.datetime("y年m月d号，H：M")))
 			item(title='GUID随机名' cmd=io.dir.create(str.guid))
 		}
-		
+
 		menu(title='新建文件' image=icon.new_file)
 		{
 			var { dt = sys.datetime("y年m月d号，H：M")}
 			item(title='TXT' cmd=io.file.create('@(dt).txt', 'Hello World!'))
 			item(title='XML' cmd=io.file.create('@(dt).xml', '<root>Hello World!</root>'))
 			item(title='JSON' cmd=io.file.create('@(dt).json', '[]'))
-			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))					
+			item(title='HTML' cmd=io.file.create('@(dt).html', "<html>\n\t<head>\n\t</head>\n\t<body>Hello World!\n\t</body>\n</html>"))
 		}
 	}
-	
+
 	item(where=!wnd.is_desktop title=title.folder_options image=icon.folder_options cmd=command.folder_options)
 }


### PR DESCRIPTION
this PR:
- sets the *File Manage* → *Attributes* → {*CREATED*, *ACCESSED*, *MODIFIED*} items to **vis=label**, because they don't make sense as regular buttons. also sets the item titles to sentence case (*Created*, *Accessed*, *Modified*).
- sets the *File Manage* and *Take Ownership* item titles to sentence case (*File manage* and *Take ownership*) for consistency. i would've liked to change *Folder Options* as well but it seems to be hard-coded as **title.folder_options**
- adds the *Properties* wrench icon to the *Attributes* item. this might not have been the best choice due to visual redundancy with *Properties*, so removal/alternatives are ok, but i do think it's better than no icon.