### PR TITLE
Add shell of CI/CD with GH Actions

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,53 @@
+name: Build artifacts from master branch with MSBuild
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        # configuration: [debug, release]
+        configuration: [release]
+        platform: [x64, x86, arm64]
+      fail-fast: false
+
+    env:
+      SOLUTION_FILE_PATH: src/Shell.sln
+      BUILD_CONFIGURATION: ${{matrix.configuration}}
+      BUILD_PLATFORM: ${{matrix.platform}}
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: artifact-${{matrix.configuration}}-${{matrix.platform}}
+        path: D:\a\nilesoft-shell\nilesoft-shell\src\bin\release\*
+        if-no-files-found: warn
+        retention-days: 0
+        compression-level: 6
+        overwrite: false
+        include-hidden-files: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Ceasefire Now](https://badge.techforpalestine.org/default)](https://techforpalestine.org/learn-more)
 
+[![Build artifacts from master branch with MSBuild](../../actions/workflows/msbuild.yml/badge.svg)](../../actions/workflows/msbuild.yml)
+
+[![Latest nightly build](https://img.shields.io/badge/download%20latest%20nightly%20build-nightly.link-purple)](https://nightly.link/moudey/Shell/workflows/msbuild/main)
+
 # [Shell](https://nilesoft.org)
 Powerful manager for Windows File Explorer context menu.
 


### PR DESCRIPTION
It's nice to be able to download absolute latest version of the software without having to clone the repo, install Visual Studio and build the repo.

This PR contains:
1. basic Github Action to build the release configuration for x86, x64 and arm64, and after the build uploads build artifacts
2. additional shields for build status and easy to use artifact download page (via nightly.link)