### PR TITLE
Correct repository name and branch name in msbuild.yml and README.md

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,4 +1,4 @@
-name: Build artifacts from master branch with MSBuild
+name: Build artifacts from main branch with MSBuild
 
 on:
   push:
@@ -45,7 +45,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: artifact-${{matrix.configuration}}-${{matrix.platform}}
-        path: D:\a\nilesoft-shell\nilesoft-shell\src\bin\release\*
+        path: D:\a\Shell\Shell\src\bin\release\*
         if-no-files-found: warn
         retention-days: 0
         compression-level: 6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Ceasefire Now](https://badge.techforpalestine.org/default)](https://techforpalestine.org/learn-more)
 
-[![Build artifacts from master branch with MSBuild](../../actions/workflows/msbuild.yml/badge.svg)](../../actions/workflows/msbuild.yml)
+[![Build artifacts from main branch with MSBuild](../../actions/workflows/msbuild.yml/badge.svg)](../../actions/workflows/msbuild.yml)
 
 [![Latest nightly build](https://img.shields.io/badge/download%20latest%20nightly%20build-nightly.link-purple)](https://nightly.link/moudey/Shell/workflows/msbuild/main)
 


### PR DESCRIPTION
Correct the repository name in upload-artifact, and branch name in README.md.

This will make GH Action actually store the artifacts.