### PR TITLE
Fix copy shortcut target path&Update install pkg config&Improving i18n

### DIFF
--- a/docs/functions/sel.html
+++ b/docs/functions/sel.html
@@ -223,9 +223,9 @@ sel(true, "\n")</code></pre>
 </section>
 <section id="sel.lnk" class="my-5">
 	<h5>sel.lnk</h5>
-	<p>Return a path from the shortcut</p>
+	<p>Return the target file/dir path from the selected shortcut</p>
 	<p>Syntax</p>
-	<code>sel.lnk(path)</code>
+	<code>sel.lnk</code>
 </section>
 <section id="sel.lnk.type" class="my-5">
 	<h5>sel.lnk.type</h5>

--- a/src/bin/imports/file-manage.nss
+++ b/src/bin/imports/file-manage.nss
@@ -2,7 +2,7 @@
 {
 	menu(separator="after" title=title.copy_path image=icon.copy_path)
 	{
-		item(where=sel.count > 1 title='Copy (@sel.count) items selected' cmd=command.copy(sel(false, "\n")))
+		item(where=sel.count > 1 title=loc.copy_multiple_paths cmd=command.copy(sel(false, "\n")))
 		item(mode="single" title=@sel.path tip=sel.path cmd=command.copy(sel.path))
 		item(mode="single" type='file' separator="before" where=length(sel.lnk)>0 title=sel.lnk cmd=command.copy(sel.lnk))
 		separator

--- a/src/bin/imports/file-manage.nss
+++ b/src/bin/imports/file-manage.nss
@@ -4,7 +4,7 @@
 	{
 		item(where=sel.count > 1 title='Copy (@sel.count) items selected' cmd=command.copy(sel(false, "\n")))
 		item(mode="single" title=@sel.path tip=sel.path cmd=command.copy(sel.path))
-		item(mode="single" type='file' separator="before" find='.lnk' title='open file location')
+		item(mode="single" type='file' separator="before" where=length(sel.lnk)>0 title=sel.lnk cmd=command.copy(sel.lnk))
 		separator
 		item(mode="single" where=@sel.parent.len>3 title=sel.parent cmd=@command.copy(sel.parent))
 		separator

--- a/src/bin/imports/lang/en.nss
+++ b/src/bin/imports/lang/en.nss
@@ -14,6 +14,7 @@ windows_notepad="Windows notepad"
 
 // file-manage.nss
 file_manage="File manage"
+copy_multiple_paths='Copy (@sel.count) items selected'
 all="All"
 invert="Invert"
 none="None"
@@ -73,6 +74,7 @@ apps="Apps"
 paint="Paint"
 edge="Edge"
 calculator="Calculator"
+windows="windows"
 cascade_windows="Cascade windows"
 Show_windows_stacked="Show windows stacked"
 Show_windows_side_by_side="Show windows side by side"

--- a/src/bin/imports/lang/zh-CN.nss
+++ b/src/bin/imports/lang/zh-CN.nss
@@ -1,8 +1,10 @@
 /*
 Simplified Chinese
 by: github.com/JohnsonRan
+    github.com/XY0797
 */
 
+xxx="欢迎用中文"
 // shell.nss
 pin_unpin="固定/取消固定"
 
@@ -13,6 +15,7 @@ windows_notepad="Windows 记事本"
 
 // file-manage.nss
 file_manage="文件管理"
+copy_multiple_paths='复制选中的 (@sel.count) 个项目'
 all="全选"
 invert="反选"
 none="全不选"
@@ -35,7 +38,7 @@ accessed="访问时间"
 new_folder="新建文件夹"
 new_file="新建文件"
 datetime="当前时间"
-guid="GUID"
+guid="Guid"
 
 // goto.nss
 folder="文件夹"
@@ -65,6 +68,7 @@ status="网络和 Internet"
 ethernet="以太网"
 wifi="WLAN"
 connections="网络连接"
+
 
 // taskbar.nss
 apps="应用"

--- a/src/bin/shell.nss
+++ b/src/bin/shell.nss
@@ -10,9 +10,10 @@
 
 // localization
 $loc_path='imports\lang\'
-import lang if(path.exists(loc_path + sys.lang + ".nss"), 
-				loc_path + sys.lang + ".nss", 
-				loc_path + "\\en.nss")
+import lang loc_path + "en.nss"
+import lang if(path.exists(loc_path + sys.lang + ".nss"),
+               loc_path + sys.lang + ".nss",
+               loc_path + "en.nss")
 
 // or import lang 'imports/lang/en.nss'
 

--- a/src/setup/wix/setup.wxs
+++ b/src/setup/wix/setup.wxs
@@ -78,6 +78,11 @@
 					<Component Id='LANG' Guid='{FF987BEA-6195-4C05-8523-00936A1BD092}' NeverOverwrite='yes'>
 						<File Id='en.nss' Source='$(var.bin)\imports\lang\en.nss' />
 						<File Id='ar.nss' Source='$(var.bin)\imports\lang\ar.nss' />
+						<File Id='de_DE.nss' Source='$(var.bin)\imports\lang\de-DE.nss' />
+						<File Id='ko.nss' Source='$(var.bin)\imports\lang\ko.nss' />
+						<File Id='no.nss' Source='$(var.bin)\imports\lang\no.nss' />
+						<File Id='pt_BR.nss' Source='$(var.bin)\imports\lang\pt-BR.nss' />
+						<File Id='zh_CN.nss' Source='$(var.bin)\imports\lang\zh-CN.nss' />
 					</Component>
 				</Directory>
 				</Directory>


### PR DESCRIPTION
1. Add translation files for other languages in `setup.wxs`.
2. The appearance of `open file location` in `copy path` is clearly incorrect; correct it to copy the target file path of the shortcut.
3. Testing has revealed that the actual behavior of `sel.lnk` does not match the documentation; amend the documentation accordingly.

Note:
In `Copy the target file path of the shortcut`, using `where=length(sel.lnk)>0` instead of `find='.lnk'` is to avoid displaying empty text when a `UWP app shortcut` is selected.
`UWP app shortcut`: Open `shell:AppsFolder`, and you can create one by right-clicking.