### PR TITLE
Update properties.html

### DIFF
--- a/docs/configuration/properties.html
+++ b/docs/configuration/properties.html
@@ -800,7 +800,7 @@ in = "Sort By"</code></pre>
 			<td>Tip</td>
 			<td>st, nm, ni</td>
 			<td>
-				<p>Show a <strong>tooltip</strong> for the current <a href="/docs/configuration/dynamic#menu">menu</a>or <a href="/docs/configuration/dynamic#item">item</a>.</p>
+				<p>Show a <strong>tooltip</strong> for the current <a href="/docs/configuration/dynamic#menu">menu</a> or <a href="/docs/configuration/dynamic#item">item</a>.</p>
 				Default = <span class="syntax-keyword">null</span><br/>
 				<strong>Syntax</strong><br/>
 				<pre><code class="lang-shell">tip = "Lorem Ipsum is simply dummy text."


### PR DESCRIPTION
Add space between "menù" and "or" in this phrase:
"Show a tooltip for the current menuor item."