### PR TITLE
fix: Resolving Compilation Errors in VS2022

### DIFF
--- a/src/shared/System.h
+++ b/src/shared/System.h
@@ -24,6 +24,7 @@
 
 #include <thread>
 #include <mutex>
+#include <chrono>
 //#include <future>
 
 //#include <filesystem>


### PR DESCRIPTION
This file references content from std::chrono but does not include `#include <chrono>`. In VS 2022, this will cause the compilation to fail.

After testing, adding `#include <chrono>` requires no additional changes, and VS 2022 can compile successfully.
![image](https://github.com/user-attachments/assets/6dad72c9-95ed-46d1-89cc-163b7fcb6e7d)
